### PR TITLE
Fixing buggy jinja templates

### DIFF
--- a/tight_cli/blueprints/providers/aws/lambda_app/templates/lambda_proxy_controller_integration_test.jinja2
+++ b/tight_cli/blueprints/providers/aws/lambda_app/templates/lambda_proxy_controller_integration_test.jinja2
@@ -14,10 +14,9 @@
 
 import os, json
 here = os.path.dirname(os.path.realpath(__file__))
-from tight.core.test_helpers import playback, record, expected_response_body
+from tight.core.test_helpers import expected_response_body
 
 def test_get_method(app, dynamo_db_session):
-    playback(__file__, dynamo_db_session, test_get_method.__name__)
     context = {}
     event = {
         'httpMethod': 'GET'


### PR DESCRIPTION
Kills our ability to do playbacks, but still retains pulling expected_response_body from yml